### PR TITLE
Avoid the edge case where block timestamp overflows to 0

### DIFF
--- a/contracts/ExampleOracleSimple.sol
+++ b/contracts/ExampleOracleSimple.sol
@@ -32,7 +32,6 @@ contract ExampleOracleSimple {
         uint112 reserve1;
         (reserve0, reserve1, blockTimestampLast) = _pair.getReserves();
         require(reserve0 != 0 && reserve1 != 0, 'ExampleOracleSimple: NO_RESERVES'); // ensure that there's liquidity in the pair
-        require(blockTimestampLast != 0, 'ExampleOracleSimple: NO_PRICE_HISTORY'); // ensure there's a price history
     }
 
     function update() external {


### PR DESCRIPTION
We are guaranteed for `price0CumulativeLast`, `price1CumulativeLast`, and `blockTimestampLast` to be set if reserves are not 0