### PR TITLE
Fix to ExampleCombinedSwapAddRemoveLiquidity.sol: using MAX_UINT approvals with the router

### DIFF
--- a/contracts/examples/ExampleCombinedSwapAddRemoveLiquidity.sol
+++ b/contracts/examples/ExampleCombinedSwapAddRemoveLiquidity.sol
@@ -7,6 +7,7 @@ import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
 
 import "../interfaces/IUniswapV2Router01.sol";
 import "../interfaces/IWETH.sol";
+import "../interfaces/IERC20.sol";
 import "../libraries/SafeMath.sol";
 import "../libraries/UniswapV2Library.sol";
 
@@ -24,6 +25,13 @@ contract ExampleCombinedSwapAddRemoveLiquidity {
         factory = factory_;
         router = router_;
         weth = weth_;
+    }
+
+    // grants unlimited approval for a token to the router unless the existing allowance is high enough
+    function approveRouter(address _token, uint256 _amount) internal {
+        if (IERC20(_token).allowance(address(this), address(router)) < _amount) {
+            TransferHelper.safeApprove(_token, address(router), uint256(-1));
+        }
     }
 
     // returns the amount of token that should be swapped in such that ratio of reserves in the pair is equivalent
@@ -56,7 +64,7 @@ contract ExampleCombinedSwapAddRemoveLiquidity {
             TransferHelper.safeTransferFrom(tokenIn, from, address(this), amountIn);
         }
         // approve for the swap, and then later the add liquidity. total is amountIn
-        TransferHelper.safeApprove(tokenIn, address(router), amountIn);
+        approveRouter(tokenIn, amountIn);
 
         {
             address[] memory path = new address[](2);
@@ -73,7 +81,7 @@ contract ExampleCombinedSwapAddRemoveLiquidity {
         }
 
         // approve the other token for the add liquidity call
-        TransferHelper.safeApprove(otherToken, address(router), amountTokenOther);
+        approveRouter(otherToken, amountTokenOther);
         amountTokenIn = amountIn.sub(swapInAmount);
 
         // no need to check that we transferred everything because minimums == total balance of this contract
@@ -136,7 +144,7 @@ contract ExampleCombinedSwapAddRemoveLiquidity {
         address pair = UniswapV2Library.pairFor(address(factory), undesiredToken, desiredToken);
         // take possession of liquidity and give access to the router
         TransferHelper.safeTransferFrom(pair, from, address(this), liquidity);
-        TransferHelper.safeApprove(pair, address(router), liquidity);
+        approveRouter(pair, liquidity);
 
         (uint amountInToSwap, uint amountOutToTransfer) = router.removeLiquidity(
             undesiredToken,
@@ -151,7 +159,7 @@ contract ExampleCombinedSwapAddRemoveLiquidity {
         );
 
         // send the amount in that we received in the burn
-        TransferHelper.safeApprove(undesiredToken, address(router), amountInToSwap);
+        approveRouter(undesiredToken, amountInToSwap);
 
         address[] memory path = new address[](2);
         path[0] = undesiredToken;

--- a/contracts/examples/ExampleCombinedSwapAddRemoveLiquidity.sol
+++ b/contracts/examples/ExampleCombinedSwapAddRemoveLiquidity.sol
@@ -29,7 +29,12 @@ contract ExampleCombinedSwapAddRemoveLiquidity {
 
     // grants unlimited approval for a token to the router unless the existing allowance is high enough
     function approveRouter(address _token, uint256 _amount) internal {
-        if (IERC20(_token).allowance(address(this), address(router)) < _amount) {
+        uint256 allowance = IERC20(_token).allowance(address(this), address(router));
+        if (allowance < _amount) {
+            if (allowance > 0) {
+                // clear the existing allowance
+                TransferHelper.safeApprove(_token, address(router), 0);
+            }
             TransferHelper.safeApprove(_token, address(router), uint256(-1));
         }
     }

--- a/test/ExampleCombinedSwapAddRemoveLiquidity.spec.ts
+++ b/test/ExampleCombinedSwapAddRemoveLiquidity.spec.ts
@@ -53,7 +53,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
     await wethPair.mint(wallet.address, overrides)
   }
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     const fixture = await loadFixture(v2Fixture)
 
     token0 = fixture.token0
@@ -145,7 +145,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
         .to.emit(token0, 'Transfer')
         .withArgs(wallet.address, combinedSwap.address, userAddToken0Amount)
         .to.emit(token0, 'Approval')
-        .withArgs(combinedSwap.address, router.address, userAddToken0Amount)
+        .withArgs(combinedSwap.address, router.address, MaxUint256)
         .to.emit(token0, 'Transfer')
         .withArgs(combinedSwap.address, pair.address, swapAmount)
         .to.emit(token1, 'Transfer')
@@ -181,7 +181,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
         .to.emit(weth, 'Deposit')
         .withArgs(combinedSwap.address, userAddETHAmount)
         .to.emit(weth, 'Approval')
-        .withArgs(combinedSwap.address, router.address, userAddETHAmount)
+        .withArgs(combinedSwap.address, router.address, MaxUint256)
         .to.emit(weth, 'Transfer')
         .withArgs(combinedSwap.address, wethPair.address, swapAmount)
         .to.emit(wethPartner, 'Transfer')
@@ -228,7 +228,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
         .to.emit(pair, 'Transfer')
         .withArgs(wallet.address, combinedSwap.address, removeLiquidityAmount)
         .to.emit(pair, 'Approval')
-        .withArgs(combinedSwap.address, router.address, removeLiquidityAmount)
+        .withArgs(combinedSwap.address, router.address, MaxUint256)
         .to.emit(pair, 'Transfer')
         .withArgs(combinedSwap.address, pair.address, removeLiquidityAmount)
         .to.emit(undesiredToken, 'Transfer')
@@ -244,7 +244,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
         )
         // then swaps the undesired token through the router
         .to.emit(undesiredToken, 'Approval')
-        .withArgs(combinedSwap.address, router.address, expectedBurnAmountUndesiredToken)
+        .withArgs(combinedSwap.address, router.address, MaxUint256)
         .to.emit(undesiredToken, 'Transfer')
         .withArgs(combinedSwap.address, pair.address, expectedBurnAmountUndesiredToken)
         .to.emit(desiredToken, 'Transfer')
@@ -304,7 +304,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
         .to.emit(wethPair, 'Transfer')
         .withArgs(wallet.address, combinedSwap.address, removeLiquidityAmount)
         .to.emit(wethPair, 'Approval')
-        .withArgs(combinedSwap.address, router.address, removeLiquidityAmount)
+        .withArgs(combinedSwap.address, router.address, MaxUint256)
         .to.emit(wethPair, 'Transfer')
         .withArgs(combinedSwap.address, wethPair.address, removeLiquidityAmount)
         .to.emit(weth, 'Transfer')
@@ -315,7 +315,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
         .withArgs(router.address, expectedBurnAmountPartner, expectedBurnAmountETH, combinedSwap.address)
         // then swaps the undesired token through the router
         .to.emit(wethPartner, 'Approval')
-        .withArgs(combinedSwap.address, router.address, expectedBurnAmountPartner)
+        .withArgs(combinedSwap.address, router.address, MaxUint256)
         .to.emit(wethPartner, 'Transfer')
         .withArgs(combinedSwap.address, wethPair.address, expectedBurnAmountPartner)
         .to.emit(weth, 'Transfer')

--- a/test/ExampleCombinedSwapAddRemoveLiquidity.spec.ts
+++ b/test/ExampleCombinedSwapAddRemoveLiquidity.spec.ts
@@ -53,7 +53,7 @@ describe('ExampleCombinedSwapAddRemoveLiquidity', () => {
     await wethPair.mint(wallet.address, overrides)
   }
 
-  beforeEach(async function () {
+  beforeEach(async function() {
     const fixture = await loadFixture(v2Fixture)
 
     token0 = fixture.token0


### PR DESCRIPTION
Some tokens like USDT do not allow approving an amount M > 0 when an existing amount N > 0 is already approved. This is to protect from an ERC20 attack vector described here https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/edit#heading=h.b32yfk54vyg9.

ExampleCombinedSwapAddRemoveLiquidity approves UniswapV2Router to pull some tokens from itself but UniswapV2Router does not always use its full allowance and sometimes leaves some residual allowance after the transaction. As a result, the next time ExampleCombinedSwapAddRemoveLiquidity tries to approve UniswapV2Router, the residual allowance makes the approval fail for tokens such as USDT.

This PR resolves this issue by approving the router to transfer MAX_UINT tokens from ExampleCombinedSwapAddRemoveLiquidity.