### PR TITLE
evm-version: petersburg

### DIFF
--- a/.waffle.json
+++ b/.waffle.json
@@ -15,7 +15,7 @@
         "": ["ast"]
       }
     },
-    "evmVersion": "istanbul",
+    "evmVersion": "petersburg",
     "optimizer": {
       "enabled": true,
       "runs": 999999

--- a/contracts/test/DeflatingERC20.sol
+++ b/contracts/test/DeflatingERC20.sol
@@ -23,7 +23,7 @@ contract DeflatingERC20 {
     constructor(uint _totalSupply) public {
         uint chainId;
         assembly {
-            chainId := chainid()
+            chainId := 60
         }
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(

--- a/contracts/test/ERC20.sol
+++ b/contracts/test/ERC20.sol
@@ -23,7 +23,7 @@ contract ERC20 {
     constructor(uint _totalSupply) public {
         uint chainId;
         assembly {
-            chainId := chainid()
+            chainId := 60
         }
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(

--- a/test/ExampleFlashSwap.spec.ts
+++ b/test/ExampleFlashSwap.spec.ts
@@ -18,7 +18,7 @@ const overrides = {
 
 describe('ExampleFlashSwap', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/test/ExampleOracleSimple.spec.ts
+++ b/test/ExampleOracleSimple.spec.ts
@@ -19,7 +19,7 @@ const token1Amount = expandTo18Decimals(10)
 
 describe('ExampleOracleSimple', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/test/ExampleSlidingWindowOracle.spec.ts
+++ b/test/ExampleSlidingWindowOracle.spec.ts
@@ -19,7 +19,7 @@ const defaultToken1Amount = expandTo18Decimals(10)
 
 describe('ExampleSlidingWindowOracle', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/test/ExampleSwapToPrice.spec.ts
+++ b/test/ExampleSwapToPrice.spec.ts
@@ -17,7 +17,7 @@ const overrides = {
 
 describe('ExampleSwapToPrice', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/test/UniswapV2Migrator.spec.ts
+++ b/test/UniswapV2Migrator.spec.ts
@@ -15,7 +15,7 @@ const overrides = {
 
 describe('UniswapV2Migrator', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/test/UniswapV2Router01.spec.ts
+++ b/test/UniswapV2Router01.spec.ts
@@ -22,7 +22,7 @@ enum RouterVersion {
 describe('UniswapV2Router{01,02}', () => {
   for (const routerVersion of Object.keys(RouterVersion)) {
     const provider = new MockProvider({
-      hardfork: 'istanbul',
+      hardfork: 'petersburg',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999
     })

--- a/test/UniswapV2Router02.spec.ts
+++ b/test/UniswapV2Router02.spec.ts
@@ -19,7 +19,7 @@ const overrides = {
 
 describe('UniswapV2Router02', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -123,7 +123,7 @@ describe('UniswapV2Router02', () => {
 
 describe('fee-on-transfer tokens', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -310,7 +310,7 @@ describe('fee-on-transfer tokens', () => {
 
 describe('fee-on-transfer tokens: reloaded', () => {
   const provider = new MockProvider({
-    hardfork: 'istanbul',
+    hardfork: 'petersburg',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })


### PR DESCRIPTION
This PR changes the evm version from `istanbul` to `petersburg`, and adapts the code to hardcode the chain id.
Before this change, I was able to `yarn test` and pass all 88 tests. After this change, the tests no longer pass:
<details>
<summary> $ yarn test</summary>

```sh
yarn run v1.22.4
$ yarn compile
$ yarn clean
$ rimraf ./build/
$ waffle .waffle.json
$ yarn copy-v1-artifacts
$ ncp ./buildV1 ./build
$ mocha


  ExampleFlashSwap
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
    1) "before each" hook for "uniswapV2Call:0"

  ExampleOracleSimple
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
    2) "before each" hook for "update"

  ExampleSlidingWindowOracle
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
    3) "before each" hook: deploy fixture for "requires granularity to be greater than 0"

  ExampleSwapToPrice
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
    4) "before each" hook for "correct router address"

  UniswapV2Migrator
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
    5) "before each" hook for "migrate"

  UniswapV2Router{01,02}
    UniswapV2Router01
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
      6) "before each" hook for "factory, WETH"
      7) "after each" hook for "factory, WETH"

  UniswapV2Router02
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
    8) "before each" hook for "quote"

  fee-on-transfer tokens
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
    9) "before each" hook for "removeLiquidityETHSupportingFeeOnTransferTokens"
    10) "after each" hook for "removeLiquidityETHSupportingFeeOnTransferTokens"

  fee-on-transfer tokens: reloaded
    swapExactTokensForTokensSupportingFeeOnTransferTokens
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
WARNING: unsupported ABI type - receive
      11) "before each" hook for "DTT -> DTT2"
      12) "after each" hook for "DTT -> DTT2"


  0 passing (6s)
  12 failing

  1) ExampleFlashSwap
       "before each" hook for "uniswapV2Call:0":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  2) ExampleOracleSimple
       "before each" hook for "update":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  3) ExampleSlidingWindowOracle
       "before each" hook: deploy fixture for "requires granularity to be greater than 0":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  4) ExampleSwapToPrice
       "before each" hook for "correct router address":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  5) UniswapV2Migrator
       "before each" hook for "migrate":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  6) UniswapV2Router{01,02}
       "before each" hook for "factory, WETH":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  7) UniswapV2Router{01,02}
       "after each" hook for "factory, WETH":
     TypeError: Cannot read property 'address' of undefined
      at Context.<anonymous> (test/UniswapV2Router01.spec.ts:124:77)
      at step (test/UniswapV2Router01.spec.ts:44:23)
      at Object.next (test/UniswapV2Router01.spec.ts:25:53)
      at /home/jordan/go/src/github.com/gochain/uniswap-v2-periphery/test/UniswapV2Router01.spec.ts:19:71
      at new Promise (<anonymous>)
      at __awaiter (test/UniswapV2Router01.spec.ts:15:12)
      at Context.<anonymous> (test/UniswapV2Router01.spec.ts:118:20)
      at processImmediate (internal/timers.js:439:21)

  8) UniswapV2Router02
       "before each" hook for "quote":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  9) fee-on-transfer tokens
       "before each" hook for "removeLiquidityETHSupportingFeeOnTransferTokens":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  10) fee-on-transfer tokens
       "after each" hook for "removeLiquidityETHSupportingFeeOnTransferTokens":
     TypeError: Cannot read property 'address' of undefined
      at Context.<anonymous> (test/UniswapV2Router02.spec.ts:270:73)
      at step (test/UniswapV2Router02.spec.ts:44:23)
      at Object.next (test/UniswapV2Router02.spec.ts:25:53)
      at /home/jordan/go/src/github.com/gochain/uniswap-v2-periphery/test/UniswapV2Router02.spec.ts:19:71
      at new Promise (<anonymous>)
      at __awaiter (test/UniswapV2Router02.spec.ts:15:12)
      at Context.<anonymous> (test/UniswapV2Router02.spec.ts:264:16)
      at processImmediate (internal/timers.js:439:21)

  11) fee-on-transfer tokens: reloaded
       "before each" hook for "DTT -> DTT2":
     RuntimeError: VM Exception while processing transaction: revert
      at Function.RuntimeError.fromResults (node_modules/ganache-core/lib/utils/runtimeerror.js:89:13)
      at module.exports (node_modules/ganache-core/lib/utils/gas/guestimation.js:142:32)

  12) fee-on-transfer tokens: reloaded
       "after each" hook for "DTT -> DTT2":
     TypeError: Cannot read property 'address' of undefined
      at Context.<anonymous> (test/UniswapV2Router02.spec.ts:512:73)
      at step (test/UniswapV2Router02.spec.ts:44:23)
      at Object.next (test/UniswapV2Router02.spec.ts:25:53)
      at /home/jordan/go/src/github.com/gochain/uniswap-v2-periphery/test/UniswapV2Router02.spec.ts:19:71
      at new Promise (<anonymous>)
      at __awaiter (test/UniswapV2Router02.spec.ts:15:12)
      at Context.<anonymous> (test/UniswapV2Router02.spec.ts:506:16)
      at processImmediate (internal/timers.js:439:21)



error Command failed with exit code 12.
```
</details>