### PR TITLE
Bug & comment fixes for Flash Swap example

### DIFF
--- a/contracts/examples/ExampleFlashSwap.sol
+++ b/contracts/examples/ExampleFlashSwap.sol
@@ -24,7 +24,7 @@ contract ExampleFlashSwap is IUniswapV2Callee {
     // but it's not possible because it requires a call to the v1 factory, which takes too much gas
     receive() external payable {}
 
-    // gets tokens/WETH via a V2 flash swap, swaps for the ETH/tokens on V1, repays V2, and keeps the rest!
+    // gets tokens/WETH via a V2 flash swap, swaps for the WETH/tokens on V1, repays V2, and keeps the rest!
     function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external override {
         address[] memory path = new address[](2);
         uint amountToken;
@@ -37,11 +37,11 @@ contract ExampleFlashSwap is IUniswapV2Callee {
         path[0] = amount0 == 0 ? token0 : token1;
         path[1] = amount0 == 0 ? token1 : token0;
         amountToken = token0 == address(WETH) ? amount1 : amount0;
-        amountETH = token0 == address(WETH) ? amount0 : amount1;
+        amountWETH = token0 == address(WETH) ? amount0 : amount1;
         }
 
         assert(path[0] == address(WETH) || path[1] == address(WETH)); // this strategy only works with a V2 WETH pair
-        IERC20 token = IERC20(path[0] == address(WETH) ? path[1] : path[0]);
+        IERC20 token = IERC20(path[0]) == address(WETH) ? path[1] : path[0];
         IUniswapV1Exchange exchangeV1 = IUniswapV1Exchange(factoryV1.getExchange(address(token))); // get V1 exchange
 
         if (amountToken > 0) {
@@ -49,10 +49,10 @@ contract ExampleFlashSwap is IUniswapV2Callee {
             token.approve(address(exchangeV1), amountToken);
             uint amountReceived = exchangeV1.tokenToEthSwapInput(amountToken, minETH, uint(-1));
             uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountToken, path)[0];
-            assert(amountReceived > amountRequired); // fail if we didn't get enough ETH back to repay our flash loan
+            assert(amountReceived > amountRequired); // fail if we didn't get enough WETH back to repay our flash loan
             WETH.deposit{value: amountRequired}();
             assert(WETH.transfer(msg.sender, amountRequired)); // return WETH to V2 pair
-            (bool success,) = sender.call{value: amountReceived - amountRequired}(new bytes(0)); // keep the rest! (ETH)
+            (bool success,) = sender.call{value: amountReceived - amountRequired}(new bytes(0)); // keep the rest! (WETH)
             assert(success);
         } else {
             (uint minTokens) = abi.decode(data, (uint)); // slippage parameter for V1, passed in by caller

--- a/contracts/examples/ExampleFlashSwap.sol
+++ b/contracts/examples/ExampleFlashSwap.sol
@@ -28,7 +28,7 @@ contract ExampleFlashSwap is IUniswapV2Callee {
     function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external override {
         address[] memory path = new address[](2);
         uint amountToken;
-        uint amountETH;
+        uint amountWETH;
         { // scope for token{0,1}, avoids stack too deep errors
         address token0 = IUniswapV2Pair(msg.sender).token0();
         address token1 = IUniswapV2Pair(msg.sender).token1();
@@ -56,9 +56,9 @@ contract ExampleFlashSwap is IUniswapV2Callee {
             assert(success);
         } else {
             (uint minTokens) = abi.decode(data, (uint)); // slippage parameter for V1, passed in by caller
-            WETH.withdraw(amountETH);
-            uint amountReceived = exchangeV1.ethToTokenSwapInput{value: amountETH}(minTokens, uint(-1));
-            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountETH, path)[0];
+            WETH.withdraw(amountWETH);
+            uint amountReceived = exchangeV1.ethToTokenSwapInput{value: amountWETH}(minTokens, uint(-1));
+            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountWETH, path)[0];
             assert(amountReceived > amountRequired); // fail if we didn't get enough tokens back to repay our flash loan
             assert(token.transfer(msg.sender, amountRequired)); // return tokens to V2 pair
             assert(token.transfer(sender, amountReceived - amountRequired)); // keep the rest! (tokens)


### PR DESCRIPTION
Some comments and variables were unbalanced with the overall code as they had **ETH** instead of **WETH**.
And line 44 had a misplaced round bracket.